### PR TITLE
Fix footer typo and implement Input component

### DIFF
--- a/src/components/common/Footer.jsx
+++ b/src/components/common/Footer.jsx
@@ -7,4 +7,3 @@ const Footer = () => (
 );
 
 export default Footer;
-``;

--- a/src/components/common/Input.jsx
+++ b/src/components/common/Input.jsx
@@ -1,10 +1,22 @@
 import PropTypes from 'prop-types';
 
-const Input = ({ label, id }) => {
-  // component code
-};
+const Input = ({ label, id, className = '', ...props }) => (
+  <div className="flex flex-col">
+    <label htmlFor={id} className="mb-1">
+      {label}
+    </label>
+    <input id={id} className={`border p-2 ${className}`} {...props} />
+  </div>
+);
 
 Input.propTypes = {
   label: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
+  className: PropTypes.string,
 };
+
+Input.defaultProps = {
+  className: '',
+};
+
+export default Input;


### PR DESCRIPTION
## Summary
- clean up extra characters in `Footer` component
- flesh out `Input` component with basic markup and prop types

## Testing
- `npm run lint` *(fails: Cannot find package '@babel/eslint-parser')*
- `npm run build` *(fails: vite not found)*